### PR TITLE
more GroupMessages (Audio, vCard, Location) Style 1

### DIFF
--- a/src/events/AllEvents.php
+++ b/src/events/AllEvents.php
@@ -54,7 +54,7 @@ abstract class AllEvents
     public function onDisconnect( $mynumber, $socket ) {}
     public function onDissectPhone( $mynumber, $phonecountry, $phonecc, $phone, $phonemcc, $phoneISO3166, $phoneISO639, $phonemnc ) {}
     public function onDissectPhoneFailed( $mynumber ){}
-    public function onGetAudio( $mynumber, $from, $id, $type, $time, $name, $size, $url, $file, $mimeType, $fileHash, $duration, $acodec ){}
+    public function onGetAudio( $mynumber, $from, $id, $type, $time, $name, $size, $url, $file, $mimeType, $fileHash, $duration, $acodec, $fromJID_ifGroup = null){}
     public function onGetBroadcastLists( $mynumber, $broadcastLists ){}
     public function onGetError( $mynumber, $from, $id, $data ){}
     public function onGetExtendAccount( $mynumber, $kind, $status, $creation, $expiration ){}
@@ -69,7 +69,7 @@ abstract class AllEvents
     public function onGetGroupImage( $mynumber, $from_group_jid, $from_user_jid, $id, $type, $time, $name, $size, $url, $file, $mimeType, $fileHash, $width, $height, $preview, $caption ){}
     public function onGetGroupVideo( $mynumber, $from_group_jid, $from_user_jid, $id, $type, $time, $name, $url, $file, $size, $mimeType, $fileHash, $duration, $vcodec, $acodec, $preview, $caption ){}
     public function onGetKeysLeft( $mynumber, $keysLeft){}
-    public function onGetLocation( $mynumber, $from, $id, $type, $time, $name, $name, $longitude, $latitude, $url, $preview ){}
+    public function onGetLocation( $mynumber, $from, $id, $type, $time, $name, $name, $longitude, $latitude, $url, $preview, $fromJID_ifGroup = null){}
     public function onGetMessage( $mynumber, $from, $id, $type, $time, $name, $body ){}
     public function onGetNormalizedJid( $mynumber, $data ){}
     public function onGetPrivacyBlockedList( $mynumber, $data ){}
@@ -81,7 +81,7 @@ abstract class AllEvents
     public function onGetStatus( $mynumber, $from, $requested, $id, $time, $data ){}
     public function onGetSyncResult( $result ){}
     public function onGetVideo( $mynumber, $from, $id, $type, $time, $name, $url, $file, $size, $mimeType, $fileHash, $duration, $vcodec, $acodec, $preview, $caption ){}
-    public function onGetvCard( $mynumber, $from, $id, $type, $time, $name, $vcardname, $vcard ){}
+    public function onGetvCard( $mynumber, $from, $id, $type, $time, $name, $vcardname, $vcard, $fromJID_ifGroup = null){}
     public function onGroupCreate( $mynumber, $groupId ){}
     public function onGroupisCreated( $mynumber, $creator, $gid, $subject, $admin, $creation, $members = array()){}
     public function onGroupsChatCreate( $mynumber, $gid ){}

--- a/src/whatsprot.class.php
+++ b/src/whatsprot.class.php
@@ -2839,6 +2839,7 @@ class WhatsProt
                             ));
                     }
                 } elseif ($node->getChild("media")->getAttribute('type') == 'audio') {
+                    $author = $node->getAttribute("participant");
                     $this->eventManager()->fire("onGetAudio",
                         array(
                             $this->phoneNumber,
@@ -2853,7 +2854,8 @@ class WhatsProt
                             $node->getChild("media")->getAttribute('mimetype'),
                             $node->getChild("media")->getAttribute('filehash'),
                             $node->getChild("media")->getAttribute('seconds'),
-                            $node->getChild("media")->getAttribute('acodec')
+                            $node->getChild("media")->getAttribute('acodec'),
+                            $author,
                         ));
                 } elseif ($node->getChild("media")->getAttribute('type') == 'vcard') {
                     if($node->getChild("media")->hasChild('vcard')) {
@@ -2863,6 +2865,7 @@ class WhatsProt
                         $name = "NO_NAME";
                         $data = $node->getChild("media")->getData();
                     }
+                    $author = $node->getAttribute("participant");
 
                     $this->eventManager()->fire("onGetvCard",
                         array(
@@ -2873,11 +2876,13 @@ class WhatsProt
                             $node->getAttribute('t'),
                             $node->getAttribute('notify'),
                             $name,
-                            $data
+                            $data,
+                            $author
                         ));
                 } elseif ($node->getChild("media")->getAttribute('type') == 'location') {
                     $url = $node->getChild("media")->getAttribute('url');
                     $name = $node->getChild("media")->getAttribute('name');
+                    $author = $node->getAttribute("participant");
 
                     $this->eventManager()->fire("onGetLocation",
                         array(
@@ -2891,7 +2896,8 @@ class WhatsProt
                             $node->getChild("media")->getAttribute('longitude'),
                             $node->getChild("media")->getAttribute('latitude'),
                             $url,
-                            $node->getChild("media")->getData()
+                            $node->getChild("media")->getData(),
+                            $author
                         ));
                 }
 


### PR DESCRIPTION
There are still 3 message types missing for groups, Audio, vCard and Location.

This style implements it right in the already existing events as additional parameter for the author/participant. (`null` if normal message, `!null` if group message)
Thus the events callback can/must decide if this message belongs to a group or not. But since the handling of normal and group message is IMHO basically mostly the same, it's fine this way. We save us having thousand of mostly similar Events which most of the time will anyway be routed to the same function in our own code.

This differs completly than already done for Text, Video, Image Messages with it's own Events.
Personally i would like to see the already existing GroupMessage Events also to be changed to this style, but this would be a BC break (at least the Image and Video ones are only some few days old).
Due to this BC, there will be a second pull request, with these missing Events done in the already existing style as distinct events.

See also #392 