### PR TITLE
call onGetGroupV2Info Event for all childs in onGetGroups

### DIFF
--- a/src/events/AllEvents.php
+++ b/src/events/AllEvents.php
@@ -60,7 +60,7 @@ abstract class AllEvents
     public function onGetGroupParticipants($mynumber, $groupId, $groupList) {}
     public function onGetGroups($mynumber, $groupList) {}
     public function onGetGroupsInfo($mynumber, $groupList) {}
-    public function onGetGroupV2Info($mynumber, $creator, $creation, $subject, $participants, $admin) {}
+    public function onGetGroupV2Info( $mynumber, $creator, $creation, $subject, $participants, $admins, $fromGetGroup ){}
     public function onGetGroupsSubject($mynumber, $group_jid, $time, $author, $name, $subject) {}
     public function onGetImage($mynumber, $from, $id, $type, $time, $name, $size, $url, $file, $mimeType, $fileHash, $width, $height, $preview, $caption) {}
     public function onGetGroupImage($mynumber, $from_group_jid, $from_user_jid, $id, $type, $time, $name, $size, $url, $file, $mimeType, $fileHash, $width, $height, $preview, $caption) {}


### PR DESCRIPTION
The response from WhatsAppServer in getGroups Response contains (child)-group nodes, which are exactly the same as the ones we get at getGroupV2Info

getGroups:
```xml
rx  <iq from="g.us" id="getgroups-1427301279-3" type="result">
rx    <groups>
rx      <group id="12345-12345" creator="12345@s.whatsapp.net" creation="1426253052" subject="abc" s_t="1426253052" s_o="12345@s.whatsapp.net">
rx        <participant jid="12345@s.whatsapp.net"></participant>
rx        <participant jid="12345@s.whatsapp.net" type="admin"></participant>
rx      </group>
rx      <group id="9876-9876" creator="9876@s.whatsapp.net" creation="1416315939" subject="Add2" s_t="1416315939" s_o="9876@s.whatsapp.net">
rx        <participant jid="9876@s.whatsapp.net" type="admin"></participant>
rx      </group>
rx    </groups>
rx  </iq>

```
getGroupV2Info:
```xml
<iq from="12345-12345@g.us" id="get_groupv2_info-1427301279-5" type="result">
rx    <group id="12345-12345" creator="12345@s.whatsapp.net" creation="1426253052" subject="abc" s_t="1426253052" s_o="12345@s.whatsapp.net">
rx      <participant jid="12345@s.whatsapp.net"></participant>
rx      <participant jid="12345@s.whatsapp.net" type="admin"></participant>
rx    </group>
rx  </iq>
```
So why not use that already present Information, instead calling getGroupV2Info for every group?

This PR will call for every group-childnode the onGetGroupV2Info Event in the onGetGroups Event.

As well, groups can have more than one admin, this is fixed as well.