### PR TITLE
Disconnect socket on stream error

### DIFF
--- a/src/whatsprot.class.php
+++ b/src/whatsprot.class.php
@@ -3259,6 +3259,11 @@ class WhatsProt
                     $node->getChild(0)->getTag()
                 ));
         }
+        
+        if ($node->getTag() == "stream:error" && $node->getChild(1)->getData() == 'Replaced by new connection')
+        {
+            $this->disconnect();    
+        }
 
         if ($node->getTag() == "notification") {
             $name = $node->getAttribute("notify");

--- a/src/whatsprot.class.php
+++ b/src/whatsprot.class.php
@@ -3260,11 +3260,6 @@ class WhatsProt
                 ));
         }
         
-        if ($node->getTag() == "stream:error" && $node->getChild(1)->getData() == 'Replaced by new connection')
-        {
-            $this->disconnect();    
-        }
-
         if ($node->getTag() == "notification") {
             $name = $node->getAttribute("notify");
             $type = $node->getAttribute("type");
@@ -3434,6 +3429,12 @@ class WhatsProt
                         throw new Exception("ib handler for " . $child->getTag() . " not implemented");
                 }
             }
+        }
+        
+        // Disconnect socket on stream error.
+        if ($node->getTag() == "stream:error")
+        {
+            $this->disconnect();    
         }
     }
 


### PR DESCRIPTION
When a new connection is initialized then the old connection should be
disconnected. This will stop for example polling scripts.